### PR TITLE
fixes deprecated NewInstance usage

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -56,7 +56,7 @@ private:
 			const int argc = 1;
 			Local<Value> argv[argc] = { Nan::New<Number>(hashlen) };
 			Local<Function> cons = Nan::New<Function>(constructor);
-			info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+			info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
 		}
 	}
 

--- a/test/generate_tests.py
+++ b/test/generate_tests.py
@@ -19,6 +19,13 @@ var assert = require('assert');
 var SHA3 = require('./../build/Release/sha3');
 var inst;
 
+function newBuffer(data, encoding) {
+  try {
+    return Buffer.from(data, encoding);
+  } catch(e) {
+    return new Buffer(data, encoding)
+  }
+}
 """
 
     for path, hashlen in FILES:
@@ -34,7 +41,7 @@ var inst;
 
                     print """// %s %s
         inst = new SHA3.SHA3Hash(%s);
-        inst.update(Buffer.from(%r, 'hex'));
+        inst.update(newBuffer(%r, 'hex'));
         assert.equal(inst.digest('hex'), %r);
         process.stdout.write(".");
 

--- a/test/generate_tests.py
+++ b/test/generate_tests.py
@@ -34,7 +34,7 @@ var inst;
 
                     print """// %s %s
         inst = new SHA3.SHA3Hash(%s);
-        inst.update(new Buffer(%r, 'hex'));
+        inst.update(Buffer.from(%r, 'hex'));
         assert.equal(inst.digest('hex'), %r);
         process.stdout.write(".");
 

--- a/test/unit_tests.js
+++ b/test/unit_tests.js
@@ -2,6 +2,14 @@ var assert = require('assert');
 var util   = require('util');
 var SHA3 = require('../').SHA3Hash;
 
+function newBuffer(data, encoding) {
+  try {
+    return Buffer.from(data, encoding);
+  } catch(e) {
+    return new Buffer(data, encoding)
+  }
+}
+
 describe('SHA3', function(){
 
   describe('constructor', function(){
@@ -61,7 +69,8 @@ describe('SHA3', function(){
 
     it('accepts a buffer as input', function(){
       var sha = new SHA3(224);
-      var buffer = Buffer.from('aloha');
+
+      var buffer = newBuffer('aloha', 'utf8');
       assert.doesNotThrow(function(){
         sha.update(buffer);
       });

--- a/test/unit_tests.js
+++ b/test/unit_tests.js
@@ -29,25 +29,25 @@ describe('SHA3', function(){
     it('throws an error with an integer hashlen of 0', function(){
       assert.throws(function(){
         new SHA3(0);
-      }, "Unsupported hash length");
+      }, "TypeError: Unsupported hash length");
     });
 
     it('throws an error with an integer which is not a supported hash length', function(){
       assert.throws(function(){
         new SHA3(225);
-      }, "Unsupported hash length");
+      }, "TypeError: Unsupported hash length");
     });
 
     it('throws an error with any non-positive integer value', function(){
       assert.throws(function(){
         new SHA3('hi');
-      }, "Unsupported hash length");
+      }, "TypeError: Unsupported hash length");
       assert.throws(function(){
         new SHA3(null);
-      }, "Unsupported hash length");
+      }, "TypeError: Unsupported hash length");
       assert.throws(function(){
         new SHA3(-1);
-      }, "Unsupported hash length");
+      }, "TypeError: Unsupported hash length");
     });
   });
 
@@ -61,7 +61,7 @@ describe('SHA3', function(){
 
     it('accepts a buffer as input', function(){
       var sha = new SHA3(224);
-      var buffer = new Buffer('aloha');
+      var buffer = Buffer.from('aloha');
       assert.doesNotThrow(function(){
         sha.update(buffer);
       });
@@ -72,7 +72,7 @@ describe('SHA3', function(){
       [1, 3.14, {}, []].forEach(function(arg){
         assert.throws(function(){
           sha.update(arg);
-        }, "Not a string or buffer");
+        }, "TypeError: Not a string or buffer");
       });
     });
   });
@@ -99,7 +99,7 @@ describe('SHA3', function(){
     it('does not support any other encoding', function(){
       assert.throws(function(){
         new SHA3().digest('buffer');
-      }, "Unsupported output encoding");
+      }, "TypeError: Unsupported output encoding");
     });
 
     it('incorporates the updates into the output', function(){


### PR DESCRIPTION
This patch updates the previous deprecated usage of NewInstance. See this [SO post](https://stackoverflow.com/questions/45388032/how-to-silence-newinstance-is-deprecated-warning-in-node-gyp-rebuild-what) for more information.

Allows the module to be installed with Node 10.

fixes #32 