### PR TITLE
✨ Add support for configurable number of permutation rounds

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 import Sponge from './sponge';
 
-const createHash = ({ allowedSizes, padding }) => function Hash(size = 512) {
+const createHash = ({ allowedSizes, padding, rounds }) => function Hash(size = 512) {
   if (!this || this.constructor !== Hash) {
     return new Hash(size);
   }
@@ -10,7 +10,7 @@ const createHash = ({ allowedSizes, padding }) => function Hash(size = 512) {
     throw new Error('Unsupported hash length');
   }
 
-  const sponge = new Sponge({ capacity: size });
+  const sponge = new Sponge({ capacity: size, rounds });
 
   this.update = (input, encoding = 'utf8') => {
     if (Buffer.isBuffer(input)) {

--- a/src/sponge/index.js
+++ b/src/sponge/index.js
@@ -28,7 +28,7 @@ const readWords = (I, O) => {
 };
 
 // eslint-disable-next-line max-statements
-const Sponge = function({ capacity, padding }) {
+const Sponge = function({ capacity, padding, rounds }) {
   const keccak = permute();
 
   const stateSize = 200;
@@ -46,7 +46,7 @@ const Sponge = function({ capacity, padding }) {
 
       if (queueOffset >= queueSize) {
         xorWords(queue, state);
-        keccak(state);
+        keccak(state, rounds);
         queueOffset = 0;
       }
     }
@@ -75,7 +75,7 @@ const Sponge = function({ capacity, padding }) {
     xorWords(output.queue, output.state);
 
     for (let offset = 0; offset < output.buffer.length; offset += queueSize) {
-      keccak(output.state);
+      keccak(output.state, rounds);
       readWords(output.state, output.buffer.slice(offset, offset + queueSize));
     }
 

--- a/src/sponge/permute/index.js
+++ b/src/sponge/permute/index.js
@@ -9,8 +9,8 @@ const permute = () => {
   const D = new Uint32Array(10);
   const W = new Uint32Array(2);
 
-  return (A) => {
-    for (let roundIndex = 0; roundIndex < 24; roundIndex++) {
+  return (A, roundCount = 24) => {
+    for (let roundIndex = 0; roundIndex < roundCount; roundIndex++) {
       theta({ A, C, D, W });
       rhoPi({ A, C, W });
       chi({ A, C });

--- a/src/sponge/permute/index.js
+++ b/src/sponge/permute/index.js
@@ -3,14 +3,16 @@ import iota from './iota';
 import rhoPi from './rho-pi';
 import theta from './theta';
 
+const MAXIMUM_ROUNDS = 24;
+
 const permute = () => {
   // Intermediate variables
   const C = new Uint32Array(10);
   const D = new Uint32Array(10);
   const W = new Uint32Array(2);
 
-  return (A, roundCount = 24) => {
-    for (let roundIndex = 0; roundIndex < roundCount; roundIndex++) {
+  return (A, roundCount = MAXIMUM_ROUNDS) => {
+    for (let roundIndex = MAXIMUM_ROUNDS - roundCount; roundIndex < MAXIMUM_ROUNDS; roundIndex++) {
       theta({ A, C, D, W });
       rhoPi({ A, C, W });
       chi({ A, C });


### PR DESCRIPTION
The standard number of rounds for Keccak, SHA-3, and SHAKE is 24.
Other algorithms using the Keccak sponge as a primitive, like KangarooTwelve and MarsupilamiFourteen, require the number of rounds to be configurable (e.g: n=12 and n=14, respectively).

This PR introduces no functional changes to documented behavior: the exported `SHA3`, `Keccak`, and `SHA3Hash` constructors behave just as before. The internal Keccak `Sponge`, though, may now accept a `rounds` option to configure the number of permutation rounds.