### PR TITLE
✨ Add support for XOF algorithms (SHAKE128 and SHAKE256)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 import { Buffer } from 'buffer';
 import Sponge from './sponge';
 
-const createHash = ({ padding }) => function Hash(size = 512) {
+const createHash = ({ allowedSizes, padding }) => function Hash(size = 512) {
   if (!this || this.constructor !== Hash) {
     return new Hash(size);
+  }
+
+  if (allowedSizes && !allowedSizes.includes(size)) {
+    throw new Error('Unsupported hash length');
   }
 
   const sponge = new Sponge({ capacity: size });
@@ -53,7 +57,7 @@ const createHash = ({ padding }) => function Hash(size = 512) {
  *
  * @see {@link https://keccak.team/files/Keccak-reference-3.0.pdf}, Section 1.1.2
  */
-const Keccak = createHash({ padding: 0x01 });
+const Keccak = createHash({ allowedSizes: [224, 256, 384, 512], padding: 0x01 });
 
 /**
  * The SHA-3 specification requires that the input message be appended with a
@@ -65,7 +69,9 @@ const Keccak = createHash({ padding: 0x01 });
  *
  * @see {@link https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf}, Section B.2
  */
-const SHA3 = createHash({ padding: 0x06 });
+const SHA3 = createHash({ allowedSizes: [224, 256, 384, 512], padding: 0x06 });
+
+const SHAKE = createHash({ allowedSizes: [128, 256], padding: 0x1F });
 
 /**
  * Provided for historical purposes. This is an alias for the *Keccak* algorithm,
@@ -83,7 +89,7 @@ const SHA3Hash = Keccak;
 SHA3.SHA3Hash = SHA3Hash;
 
 // Named exports for all hashes included by this library.
-export { Keccak, SHA3, SHA3Hash };
+export { Keccak, SHA3, SHA3Hash, SHAKE };
 
 // Make the default export useful as-is.
 export default SHA3;

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const createHash = ({ padding }) => function Hash(size = 512) {
     return new Hash(size);
   }
 
-  const sponge = new Sponge({ capacity: size, padding });
+  const sponge = new Sponge({ capacity: size });
 
   this.update = (input, encoding = 'utf8') => {
     if (Buffer.isBuffer(input)) {
@@ -21,11 +21,17 @@ const createHash = ({ padding }) => function Hash(size = 512) {
     throw new TypeError('Not a string or buffer');
   };
 
-  this.digest = (format = 'binary') => {
-    const buffer = sponge.squeeze();
-    if (format && format !== 'binary') {
-      return buffer.toString(format);
+  this.digest = (formatOrOptions = 'binary') => {
+    const options = typeof formatOrOptions === 'string' ? { format: formatOrOptions } : formatOrOptions;
+    const buffer = sponge.squeeze({
+      buffer: options.buffer,
+      padding: options.padding || padding
+    });
+
+    if (options.format && options.format !== 'binary') {
+      return buffer.toString(options.format);
     }
+
     return buffer;
   };
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -93,6 +93,15 @@ Object.keys(Algorithms).forEach((algorithm) => {
         assert.ok(Buffer.isBuffer(new Hash().digest()));
       });
 
+      it('returns a string when given named options with format of "hex"', () => {
+        assert.equal('string', typeof new Hash(512).digest({ format: 'hex' }));
+      });
+
+      it('returns the given buffer provided as a named option', () => {
+        const buffer = Buffer.alloc(64);
+        assert.equal(buffer, new Hash(512).digest({ buffer }));
+      });
+
       it('throws an error when given a bad value for encoding', () => {
         assert.throws(() => new Hash().digest('not-a-real-encoding'), 'TypeError: Unsupported output encoding');
       });

--- a/test/vectors/shake.js
+++ b/test/vectors/shake.js
@@ -1,0 +1,31 @@
+/* eslint max-lines: ["off"] */
+
+const { describe, it } = require('mocha');
+const assert = require('assert');
+const { SHAKE } = require('../../src');
+
+describe('SHAKE: Test Vectors', () => {
+  describe('https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHAKE128_Msg0.pdf', () => {
+    it('produces the expected 4096-bit hash', () => {
+      const instance = new SHAKE(128);
+      instance.update(Buffer.alloc(0));
+      assert.equal(instance.digest({ buffer: Buffer.allocUnsafe(512), format: 'hex' }), '7f9c2ba4e88f827d616045507605853ed73b8093f6efbc88eb1a6eacfa66ef263cb1eea988004b93103cfb0aeefd2a686e01fa4a58e8a3639ca8a1e3f9ae57e235b8cc873c23dc62b8d260169afa2f75ab916a58d974918835d25e6a435085b2badfd6dfaac359a5efbb7bcc4b59d538df9a04302e10c8bc1cbf1a0b3a5120ea17cda7cfad765f5623474d368ccca8af0007cd9f5e4c849f167a580b14aabdefaee7eef47cb0fca9767be1fda69419dfb927e9df07348b196691abaeb580b32def58538b8d23f87732ea63b02b4fa0f4873360e2841928cd60dd4cee8cc0d4c922a96188d032675c8ac850933c7aff1533b94c834adbb69c6115bad4692d8619f90b0cdf8a7b9c264029ac185b70b83f2801f2f4b3f70c593ea3aeeb613a7f1b1de33fd75081f592305f2e4526edc09631b10958f464d889f31ba010250fda7f1368ec2967fc84ef2ae9aff268e0b1700affc6820b523a3d917135f2dff2ee06bfe72b3124721d4a26c04e53a75e30e73a7a9c4a95d91c55d495e9f51dd0b5e9d83c6d5e8ce803aa62b8d654db53d09b8dcff273cdfeb573fad8bcd45578bec2e770d01efde86e721a3f7c6cce275dabe6e2143f1af18da7efddc4c7b70b5e345db93cc936bea323491ccb38a388f546a9ff00dd4e1300b9b2153d2041d205b443e41b45a653f2a5c4492c1add544512dda2529833462b71a41a45be97290b6f');
+    });
+  });
+
+  describe('https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHAKE256_Msg0.pdf', () => {
+    it('produces the expected 4096-bit hash', () => {
+      const instance = new SHAKE(256);
+      instance.update(Buffer.alloc(0));
+      assert.equal(instance.digest({ buffer: Buffer.allocUnsafe(512), format: 'hex' }), '46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762fd75dc4ddd8c0f200cb05019d67b592f6fc821c49479ab48640292eacb3b7c4be141e96616fb13957692cc7edd0b45ae3dc07223c8e92937bef84bc0eab862853349ec75546f58fb7c2775c38462c5010d846c185c15111e595522a6bcd16cf86f3d122109e3b1fdd943b6aec468a2d621a7c06c6a957c62b54dafc3be87567d677231395f6147293b68ceab7a9e0c58d864e8efde4e1b9a46cbe854713672f5caaae314ed9083dab4b099f8e300f01b8650f1f4b1d8fcf3f3cb53fb8e9eb2ea203bdc970f50ae55428a91f7f53ac266b28419c3778a15fd248d339ede785fb7f5a1aaa96d313eacc890936c173cdcd0fab882c45755feb3aed96d477ff96390bf9a66d1368b208e21f7c10d04a3dbd4e360633e5db4b602601c14cea737db3dcf722632cc77851cbdde2aaf0a33a07b373445df490cc8fc1e4160ff118378f11f0477de055a81a9eda57a4a2cfb0c83929d310912f729ec6cfa36c6ac6a75837143045d791cc85eff5b21932f23861bcf23a52b5da67eaf7baae0f5fb1369db78f3ac45f8c4ac5671d85735cdddb09d2b1e34a1fc066ff4a162cb263d6541274ae2fcc865f618abe27c124cd8b074ccd516301b91875824d09958f341ef274bdab0bae316339894304e35877b0c28a9b1fd166c796b9cc258a064a8f57e27f2a');
+    });
+  });
+
+  describe('https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/SHAKE128_Msg1600.pdf', () => {
+    it('produces the expected 4096-bit hash', () => {
+      const instance = new SHAKE(128);
+      instance.update(Buffer.alloc(200).fill(0xA3));
+      assert.equal(instance.digest({ buffer: Buffer.allocUnsafe(512), format: 'hex' }), '131ab8d2b594946b9c81333f9bb6e0ce75c3b93104fa3469d3917457385da037cf232ef7164a6d1eb448c8908186ad852d3f85a5cf28da1ab6fe3438171978467f1c05d58c7ef38c284c41f6c2221a76f12ab1c04082660250802294fb87180213fdef5b0ecb7df50ca1f8555be14d32e10f6edcde892c09424b29f597afc270c904556bfcb47a7d40778d390923642b3cbd0579e60908d5a000c1d08b98ef933f806445bf87f8b009ba9e94f7266122ed7ac24e5e266c42a82fa1bbefb7b8db0066e16a85e0493f07df4809aec084a593748ac3dde5a6d7aae1e8b6e5352b2d71efbb47d4caeed5e6d633805d2d323e6fd81b4684b93a2677d45e7421c2c6aea259b855a698fd7d13477a1fe53e5a4a6197dbec5ce95f505b520bcd9570c4a8265a7e01f89c0c002c59bfec6cd4a5c109258953ee5ee70cd577ee217af21fa70178f0946c9bf6ca8751793479f6b537737e40b6ed28511d8a2d7e73eb75f8daac912ff906e0ab955b083bac45a8e5e9b744c8506f37e9b4e749a184b30f43eb188d855f1b70d71ff3e50c537ac1b0f8974f0fe1a6ad295ba42f6aec74d123a7abedde6e2c0711cab36be5acb1a5a11a4b1db08ba6982efccd716929a7741cfc63aa4435e0b69a9063e880795c3dc5ef3272e11c497a91acf699fefee206227a44c9fb359fd56ac0a9a75a743cff6862f17d7259ab075216c0699511643b6439');
+    });
+  });
+});


### PR DESCRIPTION
Delivers #66.

This PR introduces support for XOF algorithms, which allow for an arbitrary output length. Additionally, the `#squeeze()` function may now accept some additional options aide in reusability for algorithms which use the Keccak sponge as a primitive, like KangarooTwelve (see #64).
