### PR TITLE
Fix Node.js 13 compatibility

### DIFF
--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -66,8 +66,6 @@ public:
 
 	static
 	NAN_MODULE_INIT(Init) {
-		Local<Context> context = target->CreationContext();
-
 		Local<String> className = Nan::New<String>("SHA3Hash").ToLocalChecked();
 
 		Local<FunctionTemplate> functionTemplate = Nan::New<FunctionTemplate>(New);
@@ -78,9 +76,9 @@ public:
 		Nan::SetPrototypeMethod(functionTemplate, "update", Update);
 		Nan::SetPrototypeMethod(functionTemplate, "digest", Digest);
 
-		Local<Function> f = functionTemplate->GetFunction(context).ToLocalChecked();
+		Local<Function> f = Nan::GetFunction(functionTemplate).ToLocalChecked();
 		constructor.Reset(f);
-		target->Set(className, f);
+		Nan::Set(target, className, f);
 	}
 
 	static


### PR DESCRIPTION
The deprecated variant of method `v8::Object::Set` without the context parameter was removed in the v8 version of Node.js 13. Use the corresponding version agnostic method from `Nan`.

Fixes the V8 API warning mentioned in https://github.com/phusion/node-sha3/issues/60#issuecomment-51483755.