### PR TITLE
🔧 Update Travis CI configuration with latest major Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 
 node_js:
-  - '12.9.1'
-  - '10.16.0'
-  - '8.16.0'
+  - '13.2.0'
+  - '12.13.1'
+  - '10.17.0'
+  - '8.16.2'
 
 notifications:
   email: false


### PR DESCRIPTION
Update test matrix to include all currently supported versions listed at https://nodejs.org/en/about/releases/.