### PR TITLE
📦 Install default `g++` instead of specific version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 
-env:
-  - CXX=g++-4.8
-
 node_js:
   - '13.2.0'
   - '12.13.1'
@@ -14,12 +11,9 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - g++-4.8
+    - g++
 
 notifications:
   email: false
 
 sudo: false
-
-before_install:
-  - $CXX --version


### PR DESCRIPTION
Installing the default version should more closely emulate what end users of this library would experience. G++ 4.8.x was last updated in 2015, and the current major version is 9.x.
