### PR TITLE
🔧 Run Travis CI build with both g++ 4.8 and the default g++ (5.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,98 @@
-language: node_js
-
-node_js:
-  - '13.2.0'
-  - '12.13.1'
-  - '10.17.0'
-  - '8.16.2'
-
-addons:
-  apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    packages:
-    - g++
-
-notifications:
-  email: false
-
-sudo: false
+matrix:
+  include:
+  - os: linux
+    language: node_js
+    node_js: "13.2.0"
+    env:
+      CC: "gcc"
+      CXX: "g++"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++
+  - os: linux
+    language: node_js
+    node_js: "12.13.1"
+    env:
+      CC: "gcc"
+      CXX: "g++"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++
+  - os: linux
+    language: node_js
+    node_js: "10.17.0"
+    env:
+      CC: "gcc"
+      CXX: "g++"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++
+  - os: linux
+    language: node_js
+    node_js: "8.16.2"
+    env:
+      CC: "gcc"
+      CXX: "g++"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++
+  - os: linux
+    language: node_js
+    node_js: "13.2.0"
+    env:
+      CC: "gcc-4.8"
+      CXX: "g++-4.8"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.8
+  - os: linux
+    language: node_js
+    node_js: "12.13.1"
+    env:
+      CC: "gcc-4.8"
+      CXX: "g++-4.8"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.8
+  - os: linux
+    language: node_js
+    node_js: "10.17.0"
+    env:
+      CC: "gcc-4.8"
+      CXX: "g++-4.8"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.8
+  - os: linux
+    language: node_js
+    node_js: "8.16.2"
+    env:
+      CC: "gcc-4.8"
+      CXX: "g++-4.8"
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.8


### PR DESCRIPTION
Supports #77.

g++ 4.8 is still the default version provided with Ubuntu Trusty LTS, so including this in the CI build matrix helps to ensure compatibility.

Other changes to the Travis CI configuration in this PR are formatting only.