### PR TITLE
📝 Add some missing documentation for SHAKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ const { SHA3 } = require('sha3');
 
 // The Keccak hash function is also available
 const { Keccak } = require('sha3');
+
+// The SHAKE extendable output function (XOF) is also available
+const { SHAKE } = require('sha3');
 ```
 
 ### ES6
@@ -49,6 +52,9 @@ import { SHA3 } from 'sha3';
 
 // The Keccak hash function is also available
 import { Keccak } from 'sha3';
+
+// The SHAKE extendable output function (XOF) is also available
+import { SHAKE } from 'sha3';
 ```
 
 ### What's in the box

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,12 @@ const Keccak = createHash({ allowedSizes: [224, 256, 384, 512], defaultSize: 512
  */
 const SHA3 = createHash({ allowedSizes: [224, 256, 384, 512], defaultSize: 512, padding: 0x06 });
 
+/**
+ * SHAKE is an 128-bit or 256-bit extendable output function (XOF) variant of
+ * Keccak that uses `0x1F` padding. (SHAKE = Secure Hash Algorithm KEccak)
+ *
+ * @see {@link https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf}, Section 6.3
+ */
 const SHAKE = createHash({ allowedSizes: [128, 256], defaultSize: 256, padding: 0x1F });
 
 /**


### PR DESCRIPTION
When support for the SHAKE128 and SHAKE256 algorithms were added, the corresponding documentation was not added to the README or as a jsdoc comment block to the relevant definition.

This changeset adds the missing documentation.